### PR TITLE
Fix InstanceAlreadyExistsException if same MBean is put twice to a MMap with the same key.

### DIFF
--- a/src/main/java/com/axonivy/jmx/internal/MMap.java
+++ b/src/main/java/com/axonivy/jmx/internal/MMap.java
@@ -51,8 +51,8 @@ public class MMap<T, V> implements Map<T, V>
     if (value != previousValue)
     {
       manager.ifAnnotatedUnregisterMBeanFor(previousValue);
+      manager.ifAnnotatedRegisterMBeanFor(value);
     }
-    manager.ifAnnotatedRegisterMBeanFor(value);
     return previousValue;
   }
 
@@ -120,12 +120,7 @@ public class MMap<T, V> implements Map<T, V>
   {
     for (Map.Entry<? extends T, ? extends V> entry : m.entrySet())
     {
-      manager.ifAnnotatedRegisterMBeanFor(entry.getValue());
-      Object previousValue = originalMap.put(entry.getKey(), entry.getValue());
-      if (previousValue != entry.getValue())
-      {
-        manager.ifAnnotatedUnregisterMBeanFor(previousValue);
-      }
+      put(entry.getKey(), entry.getValue());
     }
   }
 

--- a/src/test/java/com/axonivy/jmx/TestMMap.java
+++ b/src/test/java/com/axonivy/jmx/TestMMap.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,7 +41,15 @@ public class TestMMap extends BaseMTest<TestMMap.TestBean>
   @Before
   public void before()
   {
-    // Do not register test bean by default
+    MBeans.setRegisterMBeanErrorStrategy(MConstants.THROW_RUNTIME_EXCEPTION_ERROR_STRATEGY);
+  }
+
+  @Override
+  @After
+  public void after()
+  {
+    MBeans.setRegisterMBeanErrorStrategy(MConstants.DEFAULT_ERROR_STRATEGY);
+    MBeans.unregisterAllMBeans();
   }
 
   @Test
@@ -66,6 +75,22 @@ public class TestMMap extends BaseMTest<TestMMap.TestBean>
     testMap.put("blah", bean1);
     testMap.put("blah", bean2);
     assertThat(MBeans.getMBeanServer().isRegistered(new ObjectName("Test:name=Hello"))).isTrue();
+  }
+
+  @Test
+  public void testPutSameNameAndValue()
+  {
+    testMap.put("blah", testBean);
+    testMap.put("blah", testBean);
+    assertRegistered();
+  }
+
+  @Test
+  public void testPutNull()
+  {
+    testMap.put("blah", testBean);
+    testMap.put("blah", null);
+    assertNotRegistered();
   }
 
   @Test


### PR DESCRIPTION
#54 Fix InstanceAlreadyExistsException if same MBean is put twice to a MMap with the same key.
Add additional tests for MMap