### PR TITLE
XIVY-16780 migrate to CentralPortal infrastructure 🐫️

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM maven:3.8.6-jdk-11
+FROM maven:3.9.9-eclipse-temurin-21
 
-RUN addgroup --gid 1000 build && adduser --uid 1000 --gid 1000 --disabled-password --gecos "" build
-RUN apt-get -y update && apt-get -y install git gnupg2 openssh-client
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt update && \
+    apt install gettext-base unzip git gnupg2 ssh-client gh -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM maven:3.8.6-jdk-11
 
 RUN addgroup --gid 1000 build && adduser --uid 1000 --gid 1000 --disabled-password --gecos "" build
-RUN apt-get -y update && apt-get -y install gnupg2 && apt-get install git -y
+RUN apt-get -y update && apt-get -y install git gnupg2 openssh-client

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,27 +15,48 @@ pipeline {
     choice(name: 'deployProfile',
       description: 'Choose where the built plugin should be deployed to',
       choices: ['central.snapshots', 'maven.central.release'])
-
-    string(name: 'revision',
-      description: 'Revision for this release, e.g. newest version "1.3.0" revision should be "1" (-> 1.3.1). Note: This is only used for release target!',
-      defaultValue: '0' )
   }
 
   stages {
     stage('build') {
       steps {
         script {
+          def targetBranch = "${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
+          def officialRelease = params.deployProfile == 'maven.central.release';
+          
+          if (officialRelease) {
+            sh "git config --global user.name 'ivy-team'"
+            sh "git config --global user.email 'info@ivyteam.ch'"
+            
+            sh "git checkout -b ${targetBranch}"
+            sh "git tag -l | xargs git tag -d"
+            
+            def releasedVersion = version('-DremoveSnapshot=true')
+            sh "git add . ;git commit -m 'update versions for release ${releasedVersion}'"
+            sh "git tag \"v${releasedVersion}\" -a -m \"Official release ${releasedVersion}\""
+          }
+          
           withCredentials([string(credentialsId: 'gpg.password.axonivy', variable: 'GPG_PWD'), file(credentialsId: 'gpg.keystore.axonivy', variable: 'GPG_FILE')]) {
             sh "gpg --batch --import ${env.GPG_FILE}"
             def phase = env.BRANCH_NAME == 'master' ? 'deploy' : 'verify'
-            def mavenProps = ""
-            if (params.deployProfile == 'maven.central.release') {
-              mavenProps = "-Drevision=${params.revision}" 
+            def mavenProps = "-Dgpg.passphrase='${env.GPG_PWD}' ";
+            if (officialRelease) {
+              mavenProps += "-P ${params.deployProfile} -DautoRelease=false"
             }
-            maven cmd: "clean ${phase} " +
-              "-P ${params.deployProfile} " +
-              "-Dgpg.passphrase='${env.GPG_PWD}' " +
-              "${mavenProps}"
+            maven cmd: "clean ${phase} ${mavenProps}"
+            currentBuild.description = "<a href='https://central.sonatype.com/publishing/deployments'>deployments</a>"
+          }
+          
+          if (officialRelease) {
+            def nextVersion=version('-DnextSnapshot=true')
+            sh "git add . ;git commit -m 'prepare next dev-cycle ${nextVersion}'"
+            
+            withEnv(['GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no']) {
+              sshagent(credentials: ['github-axonivy']) {
+                sh "git push origin --tags"
+                sh "git push -u origin ${targetBranch}"
+              }
+            }
           }
         }
 
@@ -46,4 +67,12 @@ pipeline {
       }
     }
   }
+  
+}
+
+def version(def param) {
+  sh "mvn org.codehaus.mojo:versions-maven-plugin:2.18.0:set ${param} -DgenerateBackupPoms=false | grep '\\[.*' "
+  def evalCmd='mvn help:evaluate -Dexpression=\'project.version\' -q -DforceStdout'
+  def current = sh(script: evalCmd, returnStdout: true)
+  return current;
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,6 +56,11 @@ pipeline {
                 sh "git push origin --tags"
                 sh "git push -u origin ${targetBranch}"
               }
+              def message = "Prepare for next development cycle (${env.BRANCH_NAME})"
+              withCredentials([file(credentialsId: 'github-ivyteam-token-repo-manager', variable: 'tokenFile')]) {
+                sh "gh auth login --with-token < ${tokenFile}"
+                sh "gh pr create --title '${message}' --body '${message}' --head ${targetBranch} --base ${env.BRANCH_NAME}"
+              }
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
   parameters {
     choice(name: 'deployProfile',
       description: 'Choose where the built plugin should be deployed to',
-      choices: ['sonatype.snapshots', 'maven.central.release'])
+      choices: ['central.snapshots', 'maven.central.release'])
 
     string(name: 'revision',
       description: 'Revision for this release, e.g. newest version "1.3.0" revision should be "1" (-> 1.3.1). Note: This is only used for release target!',

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <skip.gpg>true</skip.gpg>
     <log4j.version>2.24.3</log4j.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <autoRelease>true</autoRelease>
+    <autoRelease>false</autoRelease>
   </properties>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.axonivy</groupId>
   <artifactId>ivymx</artifactId>
-  <version>1.2.${revision}</version>
+  <version>1.2.5-SNAPSHOT</version>
 
   <name>IVYMX - AXON IVY Java Management Extension</name>
   <description>Annotations and utility classes to register POJO's as JMX MBeans.</description>
@@ -34,7 +34,6 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <revision>5-SNAPSHOT</revision>
     <skip.gpg>true</skip.gpg>
     <log4j.version>2.24.3</log4j.version>
     <slf4j.version>2.0.17</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,16 +38,17 @@
     <skip.gpg>true</skip.gpg>
     <log4j.version>2.24.3</log4j.version>
     <slf4j.version>2.0.17</slf4j.version>
+    <autoRelease>true</autoRelease>
   </properties>
 
   <profiles>
     <profile>
-      <id>sonatype.snapshots</id>
+      <id>central.snapshots</id>
       <distributionManagement>
         <snapshotRepository>
-          <id>sonatype.snapshots</id>
+          <id>central.snapshots</id>
           <name>Maven Central Snapshots Repo</name>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+          <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
       </distributionManagement>
     </profile>
@@ -58,23 +59,23 @@
       </properties>
       <distributionManagement>
         <repository>
-          <id>sonatype.releases</id>
-          <name>Sonatype Releases Repo</name>
+          <id>central.releases</id>
+          <name>Maven Central Releases Repo</name>
           <url>https://oss.sonatype.org/content/repositories/releases/</url>
         </repository>
       </distributionManagement>
       <build>
         <plugins>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.7.0</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.7.0</version>
             <extensions>true</extensions>
             <configuration>
-              <serverId>sonatype.releases</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
-              <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
+              <publishingServerId>central.releases</publishingServerId>
+              <autoPublish>${autoRelease}</autoPublish>
+              <waitUntil>published</waitUntil>
+              <forcedStagingDirectory>${project.build.directory}/central-stage</forcedStagingDirectory>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
publishes to the new Maven CentralPortal infra:
- new repo targets
- new upload plugin

then I've automated the versioning; as the new central-portal is failing/complaining if we change a SNAPSHOT into a normal release at build-time. 